### PR TITLE
Provide full state to init, crash propagates this to terminate

### DIFF
--- a/src/Stetson.purs
+++ b/src/Stetson.purs
@@ -158,7 +158,7 @@ startClear name config@{ bindAddress, bindPort, streamHandlers: streamHandlers_,
       tuple2 req
         $ Right
             { mod: nativeModuleName ModuleNames.stetsonHandlerProxy
-            , args: unsafeToForeign handler
+            , args: unsafeToForeign { handler, innerState: unit, acceptHandlers: nil, provideHandlers: nil }
             }
 
 stop :: String -> Effect Unit


### PR DESCRIPTION
The argument type for cowboy handler's init is `State`, it's not clear if this lines up with the actual state type:
```
init(Req, State) -> {ok, Req, State}
State  :: any()
```

However in the case of a crash in `init`, this state argument does get passed to `Handler:terminate/3`, which would otherwise get the actual handler state https://github.com/ninenines/cowboy/blob/master/src/cowboy_handler.erl#L46. Since we are just proxying this we can use the state in init.

One problem with this: the `terminate` type is still a lie, as it says it gets `state` but in this PR is getting a `unit` for a crash during `init`. Maybe type `HandlerProxy.terminate` with `Nullable state` and give the `terminate` callback a `Maybe state`?